### PR TITLE
Port to latest proc-macro crates

### DIFF
--- a/glsl-layout-derive/Cargo.toml
+++ b/glsl-layout-derive/Cargo.toml
@@ -11,5 +11,6 @@ keywords = ["graphics", "glsl", "gamedev"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.13", features = ["full"] }
-quote = "0.5"
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0.1"


### PR DESCRIPTION
These old versions are getting a little bit aged, let's upgrade so the user don't need to compiled three `syn` versions.

This port is pretty dumb, but so far the tests seems to pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/glsl-layout/1)
<!-- Reviewable:end -->
