### PR TITLE
2018 Edition, nalgebra support and more flexible imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
 name = "glsl-layout"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Zakarum <scareaangel@gmail.com>"]
 description = "Provides data types and traits to build structures ready to upload into UBO."
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustgd/glsl-layout"
 keywords = ["graphics", "glsl", "gamedev"]
+edition = "2018"
 
 [features]
 bigger-arrays = []
 
 [dependencies]
 cgmath = { version = "0.16", optional = true }
-glsl-layout-derive = { version = "0.3", path = "glsl-layout-derive" }
+nalgebra = { version = "0.20", optional = true }
+glsl-layout-derive = { path = "glsl-layout-derive" }
+
+[workspace]
+members = ["glsl-layout-derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 bigger-arrays = []
 
 [dependencies]
-cgmath = { version = "0.16", optional = true }
+cgmath = { version = "0.17", optional = true }
 nalgebra = { version = "0.20", optional = true }
 glsl-layout-derive = { path = "glsl-layout-derive" }
 

--- a/glsl-layout-derive/Cargo.toml
+++ b/glsl-layout-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glsl-layout-derive"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Zakarum <scareaangel@gmail.com>"]
 description = "Custom derive for `glsl-layout` crate."
 license = "MIT/Apache-2.0"

--- a/glsl-layout-derive/src/lib.rs
+++ b/glsl-layout-derive/src/lib.rs
@@ -55,7 +55,7 @@ fn impl_uniform(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
             unsafe impl glsl_layout::Std140 for #rname {}
 
             impl glsl_layout::Uniform for #rname {
-                type Align = _glsl_layout::align::Align16;
+                type Align = glsl_layout::align::Align16;
                 type Std140 = #rname;
 
                 fn std140(&self) -> #rname {

--- a/glsl-layout-derive/src/lib.rs
+++ b/glsl-layout-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 extern crate proc_macro;
 extern crate proc_macro2;
@@ -21,13 +21,10 @@ fn impl_uniform(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let name = &ast.ident;
 
     let rname = format_ident!("LayoutStd140{}", name);
-    
+
     let fields = match &ast.data {
         syn::Data::Struct(syn::DataStruct {
-            fields: syn::Fields::Named(syn::FieldsNamed {
-                named,
-                ..
-            }),
+            fields: syn::Fields::Named(syn::FieldsNamed { named, .. }),
             ..
         }) => named,
         _ => panic!(),
@@ -108,11 +105,14 @@ fn align_type_for(aligned: &syn::Type) -> syn::TypePath {
         }),
         path: syn::Path {
             leading_colon: None,
-            segments: once(syn::PathSegment::from(syn::Ident::new("glsl_layout", Span::call_site())))
-                .chain(once(syn::Ident::new("Uniform", Span::call_site()).into()))
-                .chain(once(syn::Ident::new("Align", Span::call_site()).into()))
-                .collect(),
-        }
+            segments: once(syn::PathSegment::from(syn::Ident::new(
+                "glsl_layout",
+                Span::call_site(),
+            )))
+            .chain(once(syn::Ident::new("Uniform", Span::call_site()).into()))
+            .chain(once(syn::Ident::new("Align", Span::call_site()).into()))
+            .collect(),
+        },
     }
 }
 
@@ -128,10 +128,17 @@ fn std140_type_for(aligned: &syn::Type) -> syn::TypePath {
         }),
         path: syn::Path {
             leading_colon: None,
-            segments: once(syn::PathSegment::from(syn::Ident::new("glsl_layout", Span::call_site())))
-                .chain(once(syn::Ident::new("Uniform".into(), Span::call_site()).into()))
-                .chain(once(syn::Ident::new("Std140".into(), Span::call_site()).into()))
-                .collect(),
-        }
+            segments: once(syn::PathSegment::from(syn::Ident::new(
+                "glsl_layout",
+                Span::call_site(),
+            )))
+            .chain(once(
+                syn::Ident::new("Uniform".into(), Span::call_site()).into(),
+            ))
+            .chain(once(
+                syn::Ident::new("Std140".into(), Span::call_site()).into(),
+            ))
+            .collect(),
+        },
     }
 }

--- a/glsl-layout-derive/src/lib.rs
+++ b/glsl-layout-derive/src/lib.rs
@@ -46,17 +46,15 @@ fn impl_uniform(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     quote! {
         #[allow(bad_style)]
         const #dummy: () = {
-            extern crate glsl_layout as _glsl_layout;
-
             #[repr(C, align(16))]
             #[derive(Clone, Copy, Debug, Default)]
             pub struct #rname {#(
                 #aligned_fields,
             )*}
 
-            unsafe impl _glsl_layout::Std140 for #rname {}
+            unsafe impl glsl_layout::Std140 for #rname {}
 
-            impl _glsl_layout::Uniform for #rname {
+            impl glsl_layout::Uniform for #rname {
                 type Align = _glsl_layout::align::Align16;
                 type Std140 = #rname;
 
@@ -65,8 +63,8 @@ fn impl_uniform(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
                 }
             }
 
-            impl _glsl_layout::Uniform for #name {
-                type Align = _glsl_layout::align::Align16;
+            impl glsl_layout::Uniform for #name {
+                type Align = glsl_layout::align::Align16;
                 type Std140 = #rname;
 
                 fn std140(&self) -> #rname {
@@ -110,7 +108,7 @@ fn align_type_for(aligned: &syn::Type) -> syn::TypePath {
         }),
         path: syn::Path {
             leading_colon: None,
-            segments: once(syn::PathSegment::from(syn::Ident::new("_glsl_layout", Span::call_site())))
+            segments: once(syn::PathSegment::from(syn::Ident::new("glsl_layout", Span::call_site())))
                 .chain(once(syn::Ident::new("Uniform", Span::call_site()).into()))
                 .chain(once(syn::Ident::new("Align", Span::call_site()).into()))
                 .collect(),
@@ -130,7 +128,7 @@ fn std140_type_for(aligned: &syn::Type) -> syn::TypePath {
         }),
         path: syn::Path {
             leading_colon: None,
-            segments: once(syn::PathSegment::from(syn::Ident::new("_glsl_layout", Span::call_site())))
+            segments: once(syn::PathSegment::from(syn::Ident::new("glsl_layout", Span::call_site())))
                 .chain(once(syn::Ident::new("Uniform".into(), Span::call_site()).into()))
                 .chain(once(syn::Ident::new("Std140".into(), Span::call_site()).into()))
                 .collect(),

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,7 +1,9 @@
-use std::{marker::PhantomData, slice::{Iter as SliceIter, IterMut as SliceIterMut}};
-
-use align::Align16;
-use uniform::{Std140, Uniform};
+use crate::align::Align16;
+use crate::uniform::{Std140, Uniform};
+use std::{
+    marker::PhantomData,
+    slice::{Iter as SliceIter, IterMut as SliceIterMut},
+};
 
 pub(crate) trait MapArray<A, F> {
     fn map_array(values: A, f: F) -> Self;
@@ -69,11 +71,11 @@ where
     T: Uniform,
     A: AsMut<[Element<T>]> + AsRef<[Element<T>]>,
 {
-    pub fn iter<'a>(&'a self) -> ArrayIter<SliceIter<'a, Element<T>>> {
+    pub fn iter(&self) -> ArrayIter<SliceIter<Element<T>>> {
         ArrayIter(self.0.as_ref().iter())
     }
 
-    pub fn iter_mut<'a>(&'a mut self) -> ArrayIter<SliceIterMut<'a, Element<T>>> {
+    pub fn iter_mut(&mut self) -> ArrayIter<SliceIterMut<Element<T>>> {
         ArrayIter(self.0.as_mut().iter_mut())
     }
 }
@@ -167,20 +169,23 @@ where
 }
 
 macro_rules! impl_array {
-    ($size:tt) => {
+    ($size:expr) => {
         impl<T, U, F> MapArray<[T; $size], F> for [U; $size]
         where
             F: FnMut(T) -> U,
         {
             fn map_array(mut values: [T; $size], mut f: F) -> Self {
-                use std::{mem::forget, ptr::{read, write}};
+                use std::{
+                    mem::forget,
+                    ptr::{read, write},
+                };
 
                 unsafe {
                     // All elements of `result` is written.
                     // Each element of `values` read once and then forgotten.
                     // Hence safe in case `f` never panics.
                     // TODO: Make it panic-safe.
-                    let mut result: [U; $size] = ::std::mem::uninitialized();
+                    let mut result: [U; $size] = ::std::mem::MaybeUninit::zeroed().assume_init();
                     for i in 0..$size {
                         write(&mut result[i], f(read(&mut values[i])));
                     }
@@ -221,7 +226,8 @@ macro_rules! impl_array {
                 use std::ptr::write;
                 unsafe {
                     // All elements of `result` is written.
-                    let mut result: [Element<T::Std140>; $size] = ::std::mem::uninitialized();
+                    let mut result: [Element<T::Std140>; $size] =
+                        ::std::mem::MaybeUninit::zeroed().assume_init();
                     for i in 0..$size {
                         write(&mut result[i], self[i].std140().into());
                     }
@@ -241,7 +247,8 @@ macro_rules! impl_array {
                 use std::ptr::write;
                 unsafe {
                     // All elements of `result` is written.
-                    let mut result: [Element<T::Std140>; $size] = ::std::mem::uninitialized();
+                    let mut result: [Element<T::Std140>; $size] =
+                        ::std::mem::MaybeUninit::zeroed().assume_init();
                     for i in 0..$size {
                         write(&mut result[i], self.0[i].0.std140().into());
                     }
@@ -250,273 +257,40 @@ macro_rules! impl_array {
             }
         }
 
-        unsafe impl<T> Std140 for Array<T, [Element<T>; $size]>
-        where
-            T: Std140,
-        {
-        }
+        unsafe impl<T> Std140 for Array<T, [Element<T>; $size]> where T: Std140 {}
     };
 }
 
-impl_array!(000);
-impl_array!(001);
-impl_array!(002);
-impl_array!(003);
-impl_array!(004);
-impl_array!(005);
-impl_array!(006);
-impl_array!(007);
-impl_array!(008);
-impl_array!(009);
-impl_array!(010);
-impl_array!(011);
-impl_array!(012);
-impl_array!(013);
-impl_array!(014);
-impl_array!(015);
-impl_array!(016);
-impl_array!(017);
-impl_array!(018);
-impl_array!(019);
-impl_array!(020);
-impl_array!(021);
-impl_array!(022);
-impl_array!(023);
-impl_array!(024);
-impl_array!(025);
-impl_array!(026);
-impl_array!(027);
-impl_array!(028);
-impl_array!(029);
-impl_array!(030);
-impl_array!(031);
-impl_array!(032);
-
-#[cfg(feature = "bigger-arrays")]
-mod impl_bigger_arrays {
-    use super::*;
-    impl_array!(033);
-    impl_array!(034);
-    impl_array!(035);
-    impl_array!(036);
-    impl_array!(037);
-    impl_array!(038);
-    impl_array!(039);
-    impl_array!(040);
-    impl_array!(041);
-    impl_array!(042);
-    impl_array!(043);
-    impl_array!(044);
-    impl_array!(045);
-    impl_array!(046);
-    impl_array!(047);
-    impl_array!(048);
-    impl_array!(049);
-    impl_array!(050);
-    impl_array!(051);
-    impl_array!(052);
-    impl_array!(053);
-    impl_array!(054);
-    impl_array!(055);
-    impl_array!(056);
-    impl_array!(057);
-    impl_array!(058);
-    impl_array!(059);
-    impl_array!(060);
-    impl_array!(061);
-    impl_array!(062);
-    impl_array!(063);
-    impl_array!(064);
-    impl_array!(065);
-    impl_array!(066);
-    impl_array!(067);
-    impl_array!(068);
-    impl_array!(069);
-    impl_array!(070);
-    impl_array!(071);
-    impl_array!(072);
-    impl_array!(073);
-    impl_array!(074);
-    impl_array!(075);
-    impl_array!(076);
-    impl_array!(077);
-    impl_array!(078);
-    impl_array!(079);
-    impl_array!(080);
-    impl_array!(081);
-    impl_array!(082);
-    impl_array!(083);
-    impl_array!(084);
-    impl_array!(085);
-    impl_array!(086);
-    impl_array!(087);
-    impl_array!(088);
-    impl_array!(089);
-    impl_array!(090);
-    impl_array!(091);
-    impl_array!(092);
-    impl_array!(093);
-    impl_array!(094);
-    impl_array!(095);
-    impl_array!(096);
-    impl_array!(097);
-    impl_array!(098);
-    impl_array!(099);
-    impl_array!(100);
-    impl_array!(101);
-    impl_array!(102);
-    impl_array!(103);
-    impl_array!(104);
-    impl_array!(105);
-    impl_array!(106);
-    impl_array!(107);
-    impl_array!(108);
-    impl_array!(109);
-    impl_array!(110);
-    impl_array!(111);
-    impl_array!(112);
-    impl_array!(113);
-    impl_array!(114);
-    impl_array!(115);
-    impl_array!(116);
-    impl_array!(117);
-    impl_array!(118);
-    impl_array!(119);
-    impl_array!(120);
-    impl_array!(121);
-    impl_array!(122);
-    impl_array!(123);
-    impl_array!(124);
-    impl_array!(125);
-    impl_array!(126);
-    impl_array!(127);
-    impl_array!(128);
-    impl_array!(129);
-    impl_array!(130);
-    impl_array!(131);
-    impl_array!(132);
-    impl_array!(133);
-    impl_array!(134);
-    impl_array!(135);
-    impl_array!(136);
-    impl_array!(137);
-    impl_array!(138);
-    impl_array!(139);
-    impl_array!(140);
-    impl_array!(141);
-    impl_array!(142);
-    impl_array!(143);
-    impl_array!(144);
-    impl_array!(145);
-    impl_array!(146);
-    impl_array!(147);
-    impl_array!(148);
-    impl_array!(149);
-    impl_array!(150);
-    impl_array!(151);
-    impl_array!(152);
-    impl_array!(153);
-    impl_array!(154);
-    impl_array!(155);
-    impl_array!(156);
-    impl_array!(157);
-    impl_array!(158);
-    impl_array!(159);
-    impl_array!(160);
-    impl_array!(161);
-    impl_array!(162);
-    impl_array!(163);
-    impl_array!(164);
-    impl_array!(165);
-    impl_array!(166);
-    impl_array!(167);
-    impl_array!(168);
-    impl_array!(169);
-    impl_array!(170);
-    impl_array!(171);
-    impl_array!(172);
-    impl_array!(173);
-    impl_array!(174);
-    impl_array!(175);
-    impl_array!(176);
-    impl_array!(177);
-    impl_array!(178);
-    impl_array!(179);
-    impl_array!(180);
-    impl_array!(181);
-    impl_array!(182);
-    impl_array!(183);
-    impl_array!(184);
-    impl_array!(185);
-    impl_array!(186);
-    impl_array!(187);
-    impl_array!(188);
-    impl_array!(189);
-    impl_array!(190);
-    impl_array!(191);
-    impl_array!(192);
-    impl_array!(193);
-    impl_array!(194);
-    impl_array!(195);
-    impl_array!(196);
-    impl_array!(197);
-    impl_array!(198);
-    impl_array!(199);
-    impl_array!(200);
-    impl_array!(201);
-    impl_array!(202);
-    impl_array!(203);
-    impl_array!(204);
-    impl_array!(205);
-    impl_array!(206);
-    impl_array!(207);
-    impl_array!(208);
-    impl_array!(209);
-    impl_array!(210);
-    impl_array!(211);
-    impl_array!(212);
-    impl_array!(213);
-    impl_array!(214);
-    impl_array!(215);
-    impl_array!(216);
-    impl_array!(217);
-    impl_array!(218);
-    impl_array!(219);
-    impl_array!(220);
-    impl_array!(221);
-    impl_array!(222);
-    impl_array!(223);
-    impl_array!(224);
-    impl_array!(225);
-    impl_array!(226);
-    impl_array!(227);
-    impl_array!(228);
-    impl_array!(229);
-    impl_array!(230);
-    impl_array!(231);
-    impl_array!(232);
-    impl_array!(233);
-    impl_array!(234);
-    impl_array!(235);
-    impl_array!(236);
-    impl_array!(237);
-    impl_array!(238);
-    impl_array!(239);
-    impl_array!(240);
-    impl_array!(241);
-    impl_array!(242);
-    impl_array!(243);
-    impl_array!(244);
-    impl_array!(245);
-    impl_array!(246);
-    impl_array!(247);
-    impl_array!(248);
-    impl_array!(249);
-    impl_array!(250);
-    impl_array!(251);
-    impl_array!(252);
-    impl_array!(253);
-    impl_array!(254);
-    impl_array!(255);
-    impl_array!(256);
-}
+impl_array!(0);
+impl_array!(1);
+impl_array!(2);
+impl_array!(3);
+impl_array!(4);
+impl_array!(5);
+impl_array!(6);
+impl_array!(7);
+impl_array!(8);
+impl_array!(9);
+impl_array!(10);
+impl_array!(11);
+impl_array!(12);
+impl_array!(13);
+impl_array!(14);
+impl_array!(15);
+impl_array!(16);
+impl_array!(17);
+impl_array!(18);
+impl_array!(19);
+impl_array!(20);
+impl_array!(21);
+impl_array!(22);
+impl_array!(23);
+impl_array!(24);
+impl_array!(25);
+impl_array!(26);
+impl_array!(27);
+impl_array!(28);
+impl_array!(29);
+impl_array!(30);
+impl_array!(31);
+impl_array!(32);

--- a/src/array.rs
+++ b/src/array.rs
@@ -185,12 +185,16 @@ macro_rules! impl_array {
                     // Each element of `values` read once and then forgotten.
                     // Hence safe in case `f` never panics.
                     // TODO: Make it panic-safe.
-                    let mut result: [U; $size] = ::std::mem::MaybeUninit::zeroed().assume_init();
+                    let mut result: ::std::mem::MaybeUninit<[U; $size]> =
+                        ::std::mem::MaybeUninit::zeroed();
                     for i in 0..$size {
-                        write(&mut result[i], f(read(&mut values[i])));
+                        write(
+                            result.as_mut_ptr().cast::<U>().add(i),
+                            f(read(&mut values[i])),
+                        );
                     }
                     forget(values);
-                    result
+                    result.assume_init()
                 }
             }
         }
@@ -226,12 +230,15 @@ macro_rules! impl_array {
                 use std::ptr::write;
                 unsafe {
                     // All elements of `result` is written.
-                    let mut result: [Element<T::Std140>; $size] =
-                        ::std::mem::MaybeUninit::zeroed().assume_init();
+                    let mut result: ::std::mem::MaybeUninit<[Element<T::Std140>; $size]> =
+                        ::std::mem::MaybeUninit::zeroed();
                     for i in 0..$size {
-                        write(&mut result[i], self[i].std140().into());
+                        write(
+                            result.as_mut_ptr().cast::<Element<T::Std140>>().add(i),
+                            self[i].std140().into(),
+                        );
                     }
-                    Array(result, PhantomData)
+                    Array(result.assume_init(), PhantomData)
                 }
             }
         }
@@ -247,12 +254,15 @@ macro_rules! impl_array {
                 use std::ptr::write;
                 unsafe {
                     // All elements of `result` is written.
-                    let mut result: [Element<T::Std140>; $size] =
-                        ::std::mem::MaybeUninit::zeroed().assume_init();
+                    let mut result: ::std::mem::MaybeUninit<[Element<T::Std140>; $size]> =
+                        ::std::mem::MaybeUninit::zeroed();
                     for i in 0..$size {
-                        write(&mut result[i], self.0[i].0.std140().into());
+                        write(
+                            result.as_mut_ptr().cast::<Element<T::Std140>>().add(i),
+                            self.0[i].0.std140().into(),
+                        );
                     }
-                    Array(result, PhantomData)
+                    Array(result.assume_init(), PhantomData)
                 }
             }
         }

--- a/src/cgmath.rs
+++ b/src/cgmath.rs
@@ -1,9 +1,7 @@
-extern crate cgmath;
-
-use self::cgmath::{Matrix2, Matrix3, Matrix4, Vector2, Vector3, Vector4};
-use mat::{dmat2, dmat3, dmat4, imat2, imat3, imat4, mat2, mat3, mat4, umat2, umat3, umat4};
-use scalar::{double, float, int, uint};
-use vec::{dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4, vec2, vec3, vec4};
+use crate::mat::{dmat2, dmat3, dmat4, imat2, imat3, imat4, mat2, mat3, mat4, umat2, umat3, umat4};
+use crate::scalar::{double, float, int, uint};
+use crate::vec::{dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4, vec2, vec3, vec4};
+use cgmath::{Matrix2, Matrix3, Matrix4, Vector2, Vector3, Vector4};
 
 macro_rules! impl_vec_from_cgmath {
     ($vec:ident : $cgmath:ident => [$type:ty; $size:tt]) => {
@@ -27,37 +25,37 @@ macro_rules! impl_mat_from_cgmath {
     };
 }
 
-impl_vec_from_cgmath!(ivec2 : Vector2 => [int;      2]);
-impl_vec_from_cgmath!(ivec3 : Vector3 => [int;      3]);
-impl_vec_from_cgmath!(ivec4 : Vector4 => [int;      4]);
-impl_vec_from_cgmath!(uvec2 : Vector2 => [uint;     2]);
-impl_vec_from_cgmath!(uvec3 : Vector3 => [uint;     3]);
-impl_vec_from_cgmath!(uvec4 : Vector4 => [uint;     4]);
-impl_vec_from_cgmath!( vec2 : Vector2 => [float;    2]);
-impl_vec_from_cgmath!( vec3 : Vector3 => [float;    3]);
-impl_vec_from_cgmath!( vec4 : Vector4 => [float;    4]);
-impl_vec_from_cgmath!(dvec2 : Vector2 => [double;   2]);
-impl_vec_from_cgmath!(dvec3 : Vector3 => [double;   3]);
-impl_vec_from_cgmath!(dvec4 : Vector4 => [double;   4]);
+impl_vec_from_cgmath!(ivec2 : Vector2 => [int;    2]);
+impl_vec_from_cgmath!(ivec3 : Vector3 => [int;    3]);
+impl_vec_from_cgmath!(ivec4 : Vector4 => [int;    4]);
+impl_vec_from_cgmath!(uvec2 : Vector2 => [uint;   2]);
+impl_vec_from_cgmath!(uvec3 : Vector3 => [uint;   3]);
+impl_vec_from_cgmath!(uvec4 : Vector4 => [uint;   4]);
+impl_vec_from_cgmath!( vec2 : Vector2 => [float;  2]);
+impl_vec_from_cgmath!( vec3 : Vector3 => [float;  3]);
+impl_vec_from_cgmath!( vec4 : Vector4 => [float;  4]);
+impl_vec_from_cgmath!(dvec2 : Vector2 => [double; 2]);
+impl_vec_from_cgmath!(dvec3 : Vector3 => [double; 3]);
+impl_vec_from_cgmath!(dvec4 : Vector4 => [double; 4]);
 
-impl_mat_from_cgmath!(imat2 : Matrix2 => [int;      2]);
-impl_mat_from_cgmath!(imat3 : Matrix3 => [int;      3]);
-impl_mat_from_cgmath!(imat4 : Matrix4 => [int;      4]);
-impl_mat_from_cgmath!(umat2 : Matrix2 => [uint;     2]);
-impl_mat_from_cgmath!(umat3 : Matrix3 => [uint;     3]);
-impl_mat_from_cgmath!(umat4 : Matrix4 => [uint;     4]);
-impl_mat_from_cgmath!( mat2 : Matrix2 => [float;    2]);
-impl_mat_from_cgmath!( mat3 : Matrix3 => [float;    3]);
-impl_mat_from_cgmath!( mat4 : Matrix4 => [float;    4]);
-impl_mat_from_cgmath!(dmat2 : Matrix2 => [double;   2]);
-impl_mat_from_cgmath!(dmat3 : Matrix3 => [double;   3]);
-impl_mat_from_cgmath!(dmat4 : Matrix4 => [double;   4]);
+impl_mat_from_cgmath!(imat2 : Matrix2 => [int;    2]);
+impl_mat_from_cgmath!(imat3 : Matrix3 => [int;    3]);
+impl_mat_from_cgmath!(imat4 : Matrix4 => [int;    4]);
+impl_mat_from_cgmath!(umat2 : Matrix2 => [uint;   2]);
+impl_mat_from_cgmath!(umat3 : Matrix3 => [uint;   3]);
+impl_mat_from_cgmath!(umat4 : Matrix4 => [uint;   4]);
+impl_mat_from_cgmath!( mat2 : Matrix2 => [float;  2]);
+impl_mat_from_cgmath!( mat3 : Matrix3 => [float;  3]);
+impl_mat_from_cgmath!( mat4 : Matrix4 => [float;  4]);
+impl_mat_from_cgmath!(dmat2 : Matrix2 => [double; 2]);
+impl_mat_from_cgmath!(dmat3 : Matrix3 => [double; 3]);
+impl_mat_from_cgmath!(dmat4 : Matrix4 => [double; 4]);
 
 #[test]
 fn test_cgmath() {
-    use self::cgmath::SquareMatrix;
-    use mat::mat2;
-    use vec::dvec3;
+    use crate::mat::mat2;
+    use crate::vec::dvec3;
+    use cgmath::SquareMatrix;
 
     let _: dvec3 = Vector3::new(1.0, 2.0, 3.0).into();
     let _: mat2 = Matrix2::from_value(1.0f32).into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,9 @@ mod uniform;
 #[cfg(feature = "cgmath")]
 mod cgmath;
 
+#[cfg(feature = "nalgebra")]
+mod nalgebra;
+
 pub use array::*;
 pub use mat::*;
 pub use scalar::*;
@@ -98,3 +101,25 @@ pub use vec::*;
 extern crate glsl_layout_derive;
 #[doc(hidden)]
 pub use glsl_layout_derive::*;
+
+#[test]
+fn test_derive() {
+    use crate as glsl_layout;
+    #[derive(Copy, Clone, Uniform)]
+    struct Test {
+        a: [u32; 3],
+        b: vec2,
+        c: dmat4x3,
+    }
+}
+
+#[test]
+fn test_array() {
+    use crate as glsl_layout;
+    #[derive(Copy, Clone, Uniform)]
+    struct Test {
+        a: [u32; 3],
+        b: vec2,
+        c: [dmat4x3; 32],
+    }
+}

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -1,7 +1,9 @@
-use vec::{bvec2, bvec3, bvec4, dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4,
-          vec2, vec3, vec4};
+use crate::vec::{
+    bvec2, bvec3, bvec4, dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4, vec2, vec3,
+    vec4,
+};
 
-use array::{Array, Element};
+use crate::array::{Array, Element};
 
 /// Matrix of 2 x 2 boolean values.
 pub type bmat2x2 = Array<bvec2, [Element<bvec2>; 2]>;

--- a/src/nalgebra.rs
+++ b/src/nalgebra.rs
@@ -1,0 +1,61 @@
+use crate::mat::{dmat2, dmat3, dmat4, imat2, imat3, imat4, mat2, mat3, mat4, umat2, umat3, umat4};
+use crate::scalar::{double, float, int, uint};
+use crate::vec::{dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, uvec2, uvec3, uvec4, vec2, vec3, vec4};
+use nalgebra::{Matrix2, Matrix3, Matrix4, Vector2, Vector3, Vector4};
+
+macro_rules! impl_vec_from_nalgebra {
+    ($vec:ident : $nalgebra:ident => [$type:ty; $size:tt]) => {
+        impl From<$nalgebra<$type>> for $vec {
+            fn from(value: $nalgebra<$type>) -> Self {
+                let array: [$type; $size] = value.into();
+                array.into()
+            }
+        }
+    };
+}
+
+macro_rules! impl_mat_from_nalgebra {
+    ($mat:ident : $nalgebra:ident => [$type:ty; $size:tt]) => {
+        impl From<$nalgebra<$type>> for $mat {
+            fn from(value: $nalgebra<$type>) -> Self {
+                let array: [[$type; $size]; $size] = value.into();
+                array.into()
+            }
+        }
+    };
+}
+
+impl_vec_from_nalgebra!(ivec2 : Vector2 => [int;    2]);
+impl_vec_from_nalgebra!(ivec3 : Vector3 => [int;    3]);
+impl_vec_from_nalgebra!(ivec4 : Vector4 => [int;    4]);
+impl_vec_from_nalgebra!(uvec2 : Vector2 => [uint;   2]);
+impl_vec_from_nalgebra!(uvec3 : Vector3 => [uint;   3]);
+impl_vec_from_nalgebra!(uvec4 : Vector4 => [uint;   4]);
+impl_vec_from_nalgebra!( vec2 : Vector2 => [float;  2]);
+impl_vec_from_nalgebra!( vec3 : Vector3 => [float;  3]);
+impl_vec_from_nalgebra!( vec4 : Vector4 => [float;  4]);
+impl_vec_from_nalgebra!(dvec2 : Vector2 => [double; 2]);
+impl_vec_from_nalgebra!(dvec3 : Vector3 => [double; 3]);
+impl_vec_from_nalgebra!(dvec4 : Vector4 => [double; 4]);
+
+impl_mat_from_nalgebra!(imat2 : Matrix2 => [int;    2]);
+impl_mat_from_nalgebra!(imat3 : Matrix3 => [int;    3]);
+impl_mat_from_nalgebra!(imat4 : Matrix4 => [int;    4]);
+impl_mat_from_nalgebra!(umat2 : Matrix2 => [uint;   2]);
+impl_mat_from_nalgebra!(umat3 : Matrix3 => [uint;   3]);
+impl_mat_from_nalgebra!(umat4 : Matrix4 => [uint;   4]);
+impl_mat_from_nalgebra!( mat2 : Matrix2 => [float;  2]);
+impl_mat_from_nalgebra!( mat3 : Matrix3 => [float;  3]);
+impl_mat_from_nalgebra!( mat4 : Matrix4 => [float;  4]);
+impl_mat_from_nalgebra!(dmat2 : Matrix2 => [double; 2]);
+impl_mat_from_nalgebra!(dmat3 : Matrix3 => [double; 3]);
+impl_mat_from_nalgebra!(dmat4 : Matrix4 => [double; 4]);
+
+#[test]
+fn test_nalgebra() {
+    use crate::mat::mat2;
+    use crate::vec::dvec3;
+
+    let _: dvec3 = Vector3::new(1.0, 2.0, 3.0).into();
+    let _: mat2 = Matrix2::zeros().into();
+}

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,5 +1,5 @@
-use align::{Align4, Align8};
-use uniform::{Std140, Uniform};
+use crate::align::{Align4, Align8};
+use crate::uniform::{Std140, Uniform};
 
 macro_rules! impl_scalar {
     ($type:ty : $align:tt) => {
@@ -13,13 +13,13 @@ macro_rules! impl_scalar {
                 *self
             }
         }
-    }
+    };
 }
 
 /// Boolean value.
 #[derive(Clone, Copy, Debug, Default, PartialOrd, PartialEq, Ord, Eq, Hash)]
 pub struct boolean(u32);
-impl_scalar!(boolean : Align4);
+impl_scalar!(boolean: Align4);
 
 impl boolean {
     /// Create `boolean` from `bool`.
@@ -46,16 +46,16 @@ impl From<boolean> for bool {
 
 /// Signed integer value.
 pub type int = i32;
-impl_scalar!(int : Align4);
+impl_scalar!(int: Align4);
 
 /// Unsigned integer value.
 pub type uint = u32;
-impl_scalar!(uint : Align4);
+impl_scalar!(uint: Align4);
 
 /// floating-point value.
 pub type float = f32;
-impl_scalar!(float : Align4);
+impl_scalar!(float: Align4);
 
 /// Double-precision floating-point value.
 pub type double = f64;
-impl_scalar!(double : Align8);
+impl_scalar!(double: Align8);

--- a/src/uniform.rs
+++ b/src/uniform.rs
@@ -1,12 +1,9 @@
-
 /// Special marker trait implemented only for `std140` types.
 pub unsafe trait Std140: Sized + Uniform<Std140 = Self> {
     /// Convert to bytes-slice.
     fn as_raw(&self) -> &[u8] {
-        use std::{slice::from_raw_parts, mem::size_of};
-        unsafe {
-            from_raw_parts(self as *const Self as *const u8, size_of::<Self>())
-        }
+        use std::{mem::size_of, slice::from_raw_parts};
+        unsafe { from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
     }
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,7 +1,7 @@
-use align::{Align16, Align32, Align8};
-use array::MapArray;
-use scalar::{boolean, double, float, int, uint};
-use uniform::{Std140, Uniform};
+use crate::align::{Align16, Align32, Align8};
+use crate::array::MapArray;
+use crate::scalar::{boolean, double, float, int, uint};
+use crate::uniform::{Std140, Uniform};
 
 macro_rules! implement_vec {
     ($vec:ident => [$type:ty; $size:tt]: $align:tt) => {


### PR DESCRIPTION
* `edition = "2018"`
* Release 0.4.0
* cgmath 0.17
* Added support for nalgebra `Vector` and `Matrix` types.
* Made `Uniform` proc-macro more flexible, now an undefined `glsl_layout` namespace is used, allowing using e.g. reexports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/glsl-layout/5)
<!-- Reviewable:end -->
