### PR TITLE
Updated Glam to 0.22 and other minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.4.3] - 2022-11-NN
 ### Changed 
-- Updates `glam` version from `0.21` to `0.22`.
+- Update `glam` version from `0.21` to `0.22`.
+- Update rust edition from `2018` to `2021`.
 
 ## [0.4.2] - 2022-08-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.3] - 2022-11-NN
+### Changed 
+- Updates `glam` version from `0.21` to `0.22`.
+
 ## [0.4.2] - 2022-08-06
 ### Changed
 - Used const generics to allow any array size.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glsl-layout"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Zakarum <zakarumych@ya.ru>"]
 description = "Provides data types and traits to build structures ready to upload into UBO."
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ bigger-arrays = []
 [dependencies]
 cgmath = { version = "0.18", optional = true }
 nalgebra = { version = "0.31", optional = true }
-glam = { version = "0.21", optional = true }
+glam = { version = "0.22", optional = true }
 glsl-layout-derive = { path = "glsl-layout-derive", version = "0.4.0" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Provides data types and traits to build structures ready to uploa
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustgd/glsl-layout"
 keywords = ["graphics", "glsl", "gamedev"]
-edition = "2018"
+edition = "2021"
 
 [features]
 bigger-arrays = []

--- a/glsl-layout-derive/src/lib.rs
+++ b/glsl-layout-derive/src/lib.rs
@@ -132,12 +132,8 @@ fn std140_type_for(aligned: &syn::Type) -> syn::TypePath {
                 "glsl_layout",
                 Span::call_site(),
             )))
-            .chain(once(
-                syn::Ident::new("Uniform".into(), Span::call_site()).into(),
-            ))
-            .chain(once(
-                syn::Ident::new("Std140".into(), Span::call_site()).into(),
-            ))
+            .chain(once(syn::Ident::new("Uniform", Span::call_site()).into()))
+            .chain(once(syn::Ident::new("Std140", Span::call_site()).into()))
             .collect(),
         },
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -181,14 +181,11 @@ where
         // Use `ManuallyDrop<_>` to guard against panic safety issue.
         // Upon panic in `f`, `values` isn't dropped
         // and thus item copied by `read()` is dropped only once.
-        let mut values = ManuallyDrop::new(values);
+        let values = ManuallyDrop::new(values);
         unsafe {
             let mut result: MaybeUninit<[U; N]> = MaybeUninit::zeroed();
             for i in 0..N {
-                write(
-                    result.as_mut_ptr().cast::<U>().add(i),
-                    f(read(&mut values[i])),
-                );
+                write(result.as_mut_ptr().cast::<U>().add(i), f(read(&values[i])));
             }
             result.assume_init()
         }
@@ -228,10 +225,10 @@ where
             // All elements of `result` is written.
             let mut result: ::std::mem::MaybeUninit<[Element<T::Std140>; N]> =
                 ::std::mem::MaybeUninit::zeroed();
-            for i in 0..N {
+            for (i, item) in self.iter().enumerate().take(N) {
                 write(
                     result.as_mut_ptr().cast::<Element<T::Std140>>().add(i),
-                    self[i].std140().into(),
+                    item.std140().into(),
                 );
             }
             Array(result.assume_init(), PhantomData)

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -36,11 +36,7 @@ impl From<bool> for boolean {
 
 impl From<boolean> for bool {
     fn from(value: boolean) -> Self {
-        if value.0 == 0 {
-            false
-        } else {
-            true
-        }
+        value.0 != 0
     }
 }
 

--- a/src/uniform.rs
+++ b/src/uniform.rs
@@ -1,3 +1,5 @@
+/// # Safety
+///
 /// Special marker trait implemented only for `std140` types.
 pub unsafe trait Std140: Sized + Uniform<Std140 = Self> {
     /// Convert to bytes-slice.

--- a/src/uniform.rs
+++ b/src/uniform.rs
@@ -1,6 +1,7 @@
-/// # Safety
-///
 /// Special marker trait implemented only for `std140` types.
+///
+/// # Safety
+/// The type must not have any padding bytes
 pub unsafe trait Std140: Sized + Uniform<Std140 = Self> {
     /// Convert to bytes-slice.
     fn as_raw(&self) -> &[u8] {


### PR DESCRIPTION
Hello! This PR adds:

* `glam` updated form `0.21` to `0.22`.
* Update `Cargo.toml` rust edition from `2018` to `2021`.
* Fixes all clippy lint warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/glsl-layout/18)
<!-- Reviewable:end -->
